### PR TITLE
Fix relative path passing on commandline and add missing postprocess docker image

### DIFF
--- a/modules/local/postprocess/.Dockerfile
+++ b/modules/local/postprocess/.Dockerfile
@@ -1,0 +1,7 @@
+
+FROM continuumio/miniconda3
+
+RUN conda install --yes h5py
+RUN conda install -c bioconda --yes loompy
+RUN python -m pip install pybiomart
+RUN conda install -c conda-forge --yes scanpy


### PR DESCRIPTION
Changes:

* Pass all input files as a file channel to make sure passing relative paths on the commandline work.
* Add the missing dockerfile for postprocess.