### PR TITLE
Add lib_type options to salmon alevin

### DIFF
--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -14,7 +14,7 @@ def gffread_txp2gene_options            = modules['gffread_tx2pgene']
 def gffread_transcriptome_options       = modules['gffread_transcriptome']
 def salmon_index_options                = modules['salmon_index']
 def salmon_alevin_options               = modules['salmon_alevin']
-salmon_alevin_options.args             += ' -l ISR --dumpFeatures --dumpMtx'
+salmon_alevin_options.args             += '--dumpFeatures --dumpMtx'
 def salmon_alevinqc_options             = modules['salmon_alevinqc']
 def postprocess_options                 = modules['postprocess']
 postprocess_options.publish_dir         = 'salmon/alevin'
@@ -81,11 +81,16 @@ workflow ALEVIN {
     }
     
     // Perform quantification with salmon alevin
+    // TODO: Verify the correct library type:
+    // https://salmon.readthedocs.io/en/latest/library_type.html 
+    // for different types of chemistry and protocol
+    def lib_type = "ISR"
     SALMON_ALEVIN ( 
         reads, 
         ch_salmon_alevin_index, 
         ch_txp2gene, 
-        alevin_protocol
+        alevin_protocol,
+        lib_type
     )
     
     // Collect software versions

--- a/subworkflows/local/alevinfry.nf
+++ b/subworkflows/local/alevinfry.nf
@@ -9,7 +9,7 @@ def modules = params.modules.clone()
 
 def alevinfry_index_options                 = modules['alevinfry_index']
 def salmon_alevin_options                   = modules['salmon_alevin']
-salmon_alevin_options.args                  += ' -l IU --sketch'
+salmon_alevin_options.args                  += '--sketch'
 def alevinfry_generate_permitlist_options   = modules['alevinfry_permitlist']
 def alevinfry_collate_options               = modules['alevinfry_collate']
 def alevinfry_quant_options                 = modules['alevinfry_quant']
@@ -66,11 +66,13 @@ workflow ALEVINFRY {
     }
 
     // Align reads with alevin
+    def lib_type = "IU" 
     SALMON_ALEVIN (
         reads,
         ch_index,  
         ch_txp2gene,
-        alevin_protocol
+        alevin_protocol,
+        lib_type
     )
 
     // Build permitlist and filter index


### PR DESCRIPTION
This PR fixes the issues with salmon alevin/alevinfry workflows.
The `--libType` option of `salmon alevin` must be passed before the input files and thus cannot be passed by options.args.
A new input for the SALMON_ALEVIN module `lib_type` was added (similar to the nf-core ALEVIN_QUANT module).

The library type is currently hardcoded.
The library type for alevinfry is always IU, so this should not be a problem for that workflow.
The library type for alevin is ISR for both Drop-seq and 10x-v2 /v3 chemistry.  We should probably make a function to select the right library type based on the input protocol and chemistry.
